### PR TITLE
speed up package process when frequency packaging

### DIFF
--- a/build-artifact.sh
+++ b/build-artifact.sh
@@ -34,6 +34,9 @@ run_build() {
 
   docker run \
     -e AURORA_VERSION=$AURORA_VERSION \
+    --net=host \
+    -v /root/.gradle:/root/.gradle \
+    -v /aurora:/aurora \
     -v "$(pwd)/specs:/specs:ro" \
     -v "$(realpath $RELEASE_TAR):/src.tar.gz:ro" \
     -t "$IMAGE_NAME" /build.sh


### PR DESCRIPTION
cached gradle and pants dependency file to faster package process 
in addition, use host network mode in docker to speed up download